### PR TITLE
Add build.properties to have reproducible builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,6 @@ dist/*
 target/
 lib_managed/
 src_managed/
-project/
+
+# Build-specific
+/loggg.txt

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11


### PR DESCRIPTION
This forces the version of sbt that should be used when building this project.